### PR TITLE
ci: Use pinned image version ubuntu 22.04

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,7 @@ env:
 
 jobs:
   release-era:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v4
     - name: Store ERA release key to deploy ERA by itself via ssh checkout

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -20,21 +20,21 @@ on:
 jobs:
   lint:
     name: Run linting checks
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v4
     - run: pip install tox
     - run: tox -e lint
   mypy:
     name: Run typing checks
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - run: pip install tox
       - run: tox -e mypy
   pytest:
     name: Run pytests checks
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - run: pip install tox

--- a/Changelog.md
+++ b/Changelog.md
@@ -15,6 +15,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
+- Use pinned image version ubuntu-22.04 otherwise latest version is used which leads to
+  errors.
+
 ## [0.1.0] - 2024-10-03
 
 ### Added


### PR DESCRIPTION
<!--
  Thank you for contributing to easy-release-automation

  Please ensure your pull request follows the guidelines below to help us review it effectively.
-->

## Description

The latest ci image is used (ubuntu 24.04) which leads to errors when installing pip packages.
Therefore the pinned version ubuntu 22.04 is now in use.
In mid-term a solution should be provided to use ERA also on Ubuntu 24.04.


## Type of Change

<!--
  Please delete options that are not relevant.
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Refactoring / Code quality improvement
- [ ] Other (please describe):
